### PR TITLE
feat: Add support for PowerShell language in getSymbol function

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -48,6 +48,8 @@ export function activate(context: vscode.ExtensionContext) {
       case "rust":
       case "swift":
         return ["/**", " * ", " */"];
+      case "powershell":
+          return ["#", "# ", "#"];
       default:
         return [];
     }


### PR DESCRIPTION
- Added a new case for "powershell" in the getSymbol function.
- The function now returns the correct comment symbols ("#", "#", "#") for PowerShell scripts.