### PR TITLE
feat: Add support for PowerShell in getSymbol function and fix copyri…

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,7 +19,7 @@ export function activate(context: vscode.ExtensionContext) {
     let lastEditors = `${symbol}@LastEditors: ${header.get("author")}\n`;
     let lastEditTime = `${symbol}@LastEditTime: ${new Date().toLocaleString()}\n`;
     let description = `${symbol}Description: \n`;
-    let copyright = `${symbol}Copyright: Copyright (©)}) ${new Date().getFullYear()} ${
+    let copyright = `${symbol}Copyright: Copyright (©) ${new Date().getFullYear()} ${
       header.get("copyRight") || header.get("author")
     }. All rights reserved.\n`;
     return {
@@ -48,6 +48,8 @@ export function activate(context: vscode.ExtensionContext) {
       case "rust":
       case "swift":
         return ["/**", " * ", " */"];
+      case "powershell":
+        return ["#", "# ", "#"];
       default:
         return [];
     }


### PR DESCRIPTION
- Added support for the PowerShell language in the getSymbol function, returning the correct comment symbols ("#", "#", "#").
- Fixed the incorrect formatting in the copyright string by removing unnecessary characters.